### PR TITLE
feat: unify login flow and sync results

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,22 +3,22 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Votación Estudiantil</title>
+    <title>CEYApp - Votación Estudiantil</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer"/>
     <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
     <div class="container" id="login-section">
-        <h1 class="text-center mb-4">Iniciar Sesión</h1>
+        <h1 class="text-center mb-4">CEYApp</h1>
         <form id="login-form" class="card p-4 shadow-sm">
             <div class="mb-3">
                 <label for="username" class="form-label"><i class="fa fa-user"></i> Usuario o correo</label>
-                <input type="text" id="username" class="form-control" required>
+                <input type="text" id="username" class="form-control" placeholder="correo@ejemplo.com" required>
             </div>
             <div class="mb-3">
                 <label for="password" class="form-label"><i class="fa fa-lock"></i> Contraseña</label>
-                <input type="password" id="password" class="form-control" required>
+                <input type="password" id="password" class="form-control" placeholder="1234" required>
             </div>
             <button type="submit" class="btn btn-primary w-100">Entrar</button>
             <div id="login-error" class="text-danger mt-2"></div>

--- a/js/script.js
+++ b/js/script.js
@@ -15,6 +15,7 @@ const ADMIN_USER = 'CEYAdmin';
 const ADMIN_PASS = 'CEYAdmin2025';
 const ALT_USER = 'Alternativo';
 const ALT_PASS = 'Alternativo2025';
+const DEFAULT_PASS = '1234';
 
 let currentUser = '';
 let currentRole = '';
@@ -101,7 +102,7 @@ document.getElementById('login-form').addEventListener('submit', e => {
         currentRole = 'admin';
     } else if (user === ALT_USER && pass === ALT_PASS) {
         currentRole = 'alternate';
-    } else if (user.includes('@')) {
+    } else if (user.includes('@') && pass === DEFAULT_PASS) {
         currentRole = 'user';
     } else {
         error.textContent = 'Credenciales inválidas';
@@ -162,6 +163,9 @@ document.getElementById('submit-vote').addEventListener('click', () => {
     msg.className = 'text-success';
     updateResults();
 });
+
+// Sync results across tabs/devices when storage changes
+window.addEventListener('storage', updateResults);
 
 const exportBtn = document.getElementById('export-results');
 if (exportBtn) {


### PR DESCRIPTION
## Summary
- add project name to login screen and placeholders
- enforce default password for email users
- sync result table when storage changes

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a498f642c0832594a7915eac69b90f