### PR TITLE
Remove visible login credentials from login screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,14 +56,14 @@
                   <label for="username" class="form-label">
                     <i class="fa fa-user me-1"></i> Usuario o correo
                   </label>
-                  <input type="text" id="username" class="form-control" placeholder="CEYAdmin | Alternativo | correo@ejemplo.com" required>
+                  <input type="text" id="username" class="form-control" placeholder="Usuario o correo" required>
                   <div class="invalid-feedback">Ingresa tu usuario o correo.</div>
                 </div>
                 <div class="mb-3">
                   <label for="password" class="form-label">
                     <i class="fa fa-lock me-1"></i> Contraseña
                   </label>
-                  <input type="password" id="password" class="form-control" placeholder="CEYAdmin2025 | Alternativo2025 | 1-4" required>
+                  <input type="password" id="password" class="form-control" placeholder="Contraseña" required>
                   <div class="invalid-feedback">Ingresa tu contraseña.</div>
                 </div>
                 <button type="submit" class="btn btn-primary w-100">
@@ -71,11 +71,6 @@
                 </button>
               </form>
               <div id="login-alert" class="mt-3"></div>
-              <div class="small text-muted mt-3">
-                <p class="mb-1">Admin: <code>CEYAdmin / CEYAdmin2025</code></p>
-                <p class="mb-1">Alternativo: <code>Alternativo / Alternativo2025</code></p>
-                <p class="mb-0">Usuario normal: <code>cualquier@correo</code> + contraseña <code>1</code>, <code>2</code>, <code>3</code> o <code>4</code></p>
-              </div>
             </div>
           </div>
         </div>

--- a/js/app.js
+++ b/js/app.js
@@ -33,6 +33,7 @@
   const voteAlert     = el("vote-alert");
   const myVoteBox     = el("my-vote");
   const myVoteBody    = el("my-vote-body");
+  const loginForm     = el("login-form");
 
   // Admin gestione
   const formAddStudent = el("form-add-student");
@@ -201,6 +202,9 @@
       adminSection.classList.add("d-none");
       sessionPill.classList.add("d-none");
       btnLogout.classList.add("d-none");
+      loginForm.reset();
+      loginForm.classList.remove("was-validated");
+      clearAlert("login-alert");
       return;
     }
     // con sesión
@@ -266,7 +270,7 @@
       return;
     }
 
-    // Usuario normal: debe parecer correo y pass ∈ {1,2,3,4}
+    // Usuario normal: debe parecer correo y usar la contraseña por defecto
     const isEmail = user.includes("@") && userLower.indexOf("@") > 0 && userLower.split("@")[1].includes(".");
     const validPass = CFG.normalPasswords.includes(pass);
     if (isEmail && validPass) {

--- a/js/config.js
+++ b/js/config.js
@@ -8,7 +8,7 @@ window.CEYAPP_CONFIG = {
   adminPass: "CEYAdmin2025",
   altUser: "Alternativo",
   altPass: "Alternativo2025",
-  normalPasswords: ["1", "2", "3", "4"],
+  normalPasswords: ["1234"],
 
   // Lista inicial (editable en runtime por el admin)
   defaultStudents: [


### PR DESCRIPTION
## Summary
- Replace credential placeholders with neutral text
- Remove sample login credentials from login page
- Clear login fields on logout
- Set normal user password to 1234

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4dd83e6808325898b6058a07d387a